### PR TITLE
[BE] 메뉴 상세 항목을 반환해 주는 API 추가

### DIFF
--- a/backend/src/main/java/kr/codesquad/kiosk/category/domain/Category.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/domain/Category.java
@@ -1,4 +1,4 @@
-package kr.codesquad.kiosk.domain;
+package kr.codesquad.kiosk.category.domain;
 
 import lombok.Getter;
 

--- a/backend/src/main/java/kr/codesquad/kiosk/exception/BusinessException.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/exception/BusinessException.java
@@ -1,0 +1,12 @@
+package kr.codesquad.kiosk.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public BusinessException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorCode.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorCode.java
@@ -1,0 +1,13 @@
+package kr.codesquad.kiosk.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+	ITEM_NOT_FOUND(404, "해당 아이템을 찾을 수 없습니다.");
+
+	private final int statusCode;
+	private final String description;
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorResponse.java
@@ -1,0 +1,7 @@
+package kr.codesquad.kiosk.exception;
+
+public record ErrorResponse(
+		ErrorCode errorCode,
+		String message
+) {
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/exception/GlobalExceptionHandler.java
@@ -1,0 +1,14 @@
+package kr.codesquad.kiosk.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex) {
+		return ResponseEntity.status(ex.getErrorCode().getStatusCode())
+				.body(new ErrorResponse(ex.getErrorCode(), ex.getErrorCode().getDescription()));
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/item/controller/ItemController.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/item/controller/ItemController.java
@@ -1,0 +1,21 @@
+package kr.codesquad.kiosk.item.controller;
+
+import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
+import kr.codesquad.kiosk.item.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class ItemController {
+	private final ItemService itemService;
+
+	@GetMapping("/api/categories/{categoryId}/items/{itemId}")
+	public ResponseEntity<ItemDetailsResponse> getItemDetails(@PathVariable Integer itemId) {
+		return ResponseEntity.ok()
+				.body(itemService.getItemDetails(itemId));
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/item/controller/dto/response/ItemDetailsResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/item/controller/dto/response/ItemDetailsResponse.java
@@ -1,0 +1,25 @@
+package kr.codesquad.kiosk.item.controller.dto.response;
+
+import kr.codesquad.kiosk.item.domain.Item;
+
+import java.util.List;
+import java.util.Map;
+
+public record ItemDetailsResponse(
+		Integer id,
+		String name,
+		Integer price,
+		String description,
+		String image,
+		Map<String, List<String>> options
+) {
+	public static ItemDetailsResponse from(Item item, Map<String, List<String>> options) {
+		return new ItemDetailsResponse(
+				item.getId(),
+				item.getName(),
+				item.getPrice(),
+				item.getDescription(),
+				item.getImage(),
+				options);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/item/domain/Item.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/item/domain/Item.java
@@ -1,8 +1,10 @@
-package kr.codesquad.kiosk.domain;
+package kr.codesquad.kiosk.item.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class Item {
 	private int id;
 	private String name;

--- a/backend/src/main/java/kr/codesquad/kiosk/item/domain/ItemOption.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/item/domain/ItemOption.java
@@ -1,4 +1,4 @@
-package kr.codesquad.kiosk.domain;
+package kr.codesquad.kiosk.item.domain;
 
 import lombok.Getter;
 

--- a/backend/src/main/java/kr/codesquad/kiosk/item/domain/Options.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/item/domain/Options.java
@@ -1,7 +1,9 @@
-package kr.codesquad.kiosk.domain;
+package kr.codesquad.kiosk.item.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public class Options {
 	private int id;

--- a/backend/src/main/java/kr/codesquad/kiosk/item/repository/ItemRepository.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/item/repository/ItemRepository.java
@@ -54,6 +54,10 @@ public class ItemRepository {
 						rs.getInt("option_id")
 				));
 
+		return createOptionMap(itemOptionDtos);
+	}
+
+	private Map<String, List<Options>> createOptionMap(List<ItemOptionDto> itemOptionDtos) {
 		Map<String, List<Options>> map = new HashMap<>();
 		itemOptionDtos.forEach(itemOption -> map.merge(itemOption.optionTypeName,
 				List.of(new Options(itemOption.optionId, itemOption.optionName)),

--- a/backend/src/main/java/kr/codesquad/kiosk/item/repository/ItemRepository.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/item/repository/ItemRepository.java
@@ -1,0 +1,68 @@
+package kr.codesquad.kiosk.item.repository;
+
+import kr.codesquad.kiosk.item.domain.Item;
+import kr.codesquad.kiosk.item.domain.Options;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@RequiredArgsConstructor
+@Repository
+public class ItemRepository {
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+	private final RowMapper<Item> itemRowMapper = (rs, rowNum) -> new Item(
+			rs.getInt("id"),
+			rs.getString("name"),
+			rs.getInt("price"),
+			rs.getString("image"),
+			rs.getString("description"),
+			rs.getInt("category_id")
+	);
+
+	public Optional<Item> findById(Integer id) {
+		try {
+			return Optional.ofNullable(
+					jdbcTemplate.queryForObject("SELECT id, name, price, image, description, category_id FROM item WHERE id = :id",
+							Map.of("id", id),
+							itemRowMapper));
+		} catch (EmptyResultDataAccessException ex) {
+			return Optional.empty();
+		}
+	}
+
+	private record ItemOptionDto(
+			String optionTypeName,
+			String optionName,
+			Integer optionId
+	) {
+	}
+
+	public Map<String, List<Options>> findOptionsByItemId(Integer itemId) {
+		List<ItemOptionDto> itemOptionDtos = jdbcTemplate.query("SELECT ot.name AS option_type_name, o.name AS option_name, o.id AS option_id " +
+						"FROM item_option io " +
+						"JOIN options o ON io.options_id = o.id " +
+						"JOIN option_type ot ON o.option_type_id = ot.id " +
+						"WHERE io.item_id = :itemId",
+				Map.of("itemId", itemId),
+				(rs, row) -> new ItemOptionDto(
+						rs.getString("option_type_name"),
+						rs.getString("option_name"),
+						rs.getInt("option_id")
+				));
+
+		Map<String, List<Options>> map = new HashMap<>();
+		itemOptionDtos.forEach(itemOption -> map.merge(itemOption.optionTypeName,
+				List.of(new Options(itemOption.optionId, itemOption.optionName)),
+				(v1, v2) -> {
+					List<Options> options = new ArrayList<>();
+					options.addAll(v1);
+					options.addAll(v2);
+					return options;
+				}));
+		return map;
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/item/service/ItemService.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/item/service/ItemService.java
@@ -1,0 +1,30 @@
+package kr.codesquad.kiosk.item.service;
+
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
+import kr.codesquad.kiosk.item.domain.Item;
+import kr.codesquad.kiosk.item.domain.Options;
+import kr.codesquad.kiosk.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class ItemService {
+	private final ItemRepository itemRepository;
+
+	public ItemDetailsResponse getItemDetails(Integer itemId) {
+		Item item = itemRepository.findById(itemId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+		Map<String, List<String>> options = new HashMap<>();
+		for (Map.Entry<String, List<Options>> entry : itemRepository.findOptionsByItemId(itemId).entrySet()) {
+			options.put(entry.getKey(), entry.getValue().stream().map(Options::getName).toList());
+		}
+		return ItemDetailsResponse.from(item, options);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/item/service/ItemService.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/item/service/ItemService.java
@@ -8,6 +8,7 @@ import kr.codesquad.kiosk.item.domain.Options;
 import kr.codesquad.kiosk.item.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.Map;
 public class ItemService {
 	private final ItemRepository itemRepository;
 
+	@Transactional(readOnly = true)
 	public ItemDetailsResponse getItemDetails(Integer itemId) {
 		Item item = itemRepository.findById(itemId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));

--- a/backend/src/main/java/kr/codesquad/kiosk/orderitem/domain/OrderItem.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orderitem/domain/OrderItem.java
@@ -1,4 +1,4 @@
-package kr.codesquad.kiosk.domain;
+package kr.codesquad.kiosk.orderitem.domain;
 
 import lombok.Getter;
 

--- a/backend/src/main/java/kr/codesquad/kiosk/orderitem/domain/OrderItemOption.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orderitem/domain/OrderItemOption.java
@@ -1,4 +1,4 @@
-package kr.codesquad.kiosk.domain;
+package kr.codesquad.kiosk.orderitem.domain;
 
 import lombok.Getter;
 

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/domain/Orders.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/domain/Orders.java
@@ -1,4 +1,4 @@
-package kr.codesquad.kiosk.domain;
+package kr.codesquad.kiosk.orders.domain;
 
 import lombok.Getter;
 

--- a/backend/src/main/java/kr/codesquad/kiosk/payment/domain/Payment.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/payment/domain/Payment.java
@@ -1,4 +1,4 @@
-package kr.codesquad.kiosk.domain;
+package kr.codesquad.kiosk.payment.domain;
 
 import lombok.Getter;
 

--- a/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
@@ -1,0 +1,28 @@
+package kr.codesquad.kiosk.fixture;
+
+import kr.codesquad.kiosk.item.domain.Item;
+import kr.codesquad.kiosk.item.domain.Options;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FixtureFactory {
+
+	public static Item createItem() {
+		return new Item(1, "콜드 브루", 5000, "url", "description", 1);
+	}
+
+	public static Map<String, List<String>> createOptions() {
+		Map<String, List<String>> map = new HashMap<>();
+		map.put("Size", List.of("Small", "Medium", "Large"));
+		map.put("Temperature", List.of("Ice"));
+
+		return map;
+	}
+
+	public static Map<String, List<Options>> createOptionsMap() {
+		return Map.of("Size", List.of(new Options(1, "Small"), new Options(2, "Medium"), new Options(3, "Large")),
+				"Temperature", List.of(new Options(4, "Ice")));
+	}
+}

--- a/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
@@ -1,5 +1,6 @@
 package kr.codesquad.kiosk.fixture;
 
+import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
 import kr.codesquad.kiosk.item.domain.Item;
 import kr.codesquad.kiosk.item.domain.Options;
 
@@ -8,6 +9,10 @@ import java.util.List;
 import java.util.Map;
 
 public class FixtureFactory {
+
+	public static ItemDetailsResponse createItemDetailsResponse() {
+		return ItemDetailsResponse.from(createItem(), createOptions());
+	}
 
 	public static Item createItem() {
 		return new Item(1, "콜드 브루", 5000, "url", "description", 1);

--- a/backend/src/test/java/kr/codesquad/kiosk/item/controller/ItemControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/item/controller/ItemControllerTest.java
@@ -1,0 +1,45 @@
+package kr.codesquad.kiosk.item.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import kr.codesquad.kiosk.fixture.FixtureFactory;
+import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
+import kr.codesquad.kiosk.item.service.ItemService;
+
+@WebMvcTest(controllers = ItemController.class)
+class ItemControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	ItemService itemService;
+
+	@DisplayName("아이템 아이디로 아이템 하나의 세부 항목을 조회할 수 있다.")
+	@Test
+	void givenItemId_whenGetItemDetails_thenResponse200OK() throws Exception {
+		// given
+		int itemId = 1;
+		ItemDetailsResponse response = FixtureFactory.createItemDetailsResponse();
+		when(itemService.getItemDetails(itemId)).thenReturn(response);
+
+		// when & then
+		mockMvc.perform(
+				get("/api/categories/1/items/" + itemId)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(response.id()));
+	}
+}
+

--- a/backend/src/test/java/kr/codesquad/kiosk/item/controller/ItemControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/item/controller/ItemControllerTest.java
@@ -12,6 +12,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
 import kr.codesquad.kiosk.fixture.FixtureFactory;
 import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
 import kr.codesquad.kiosk.item.service.ItemService;
@@ -39,7 +41,25 @@ class ItemControllerTest {
 			)
 			.andDo(print())
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.id").value(response.id()));
+			.andExpect(jsonPath("$.id").value(response.id()))
+			.andExpect(jsonPath("$.name").exists())
+			.andExpect(jsonPath("$.price").exists())
+			.andExpect(jsonPath("$.description").exists())
+			.andExpect(jsonPath("$.image").exists())
+			.andExpect(jsonPath("$.options").exists());
+	}
+
+	@DisplayName("존재하지 않는 아이템 아이디로 아이템 하나의 세부 항목을 조회한 경우 404 Not Found를 반환한다.")
+	@Test
+	void givenDoesNotExistItemId_whenGetItemDetails_thenResponse404NotFound() throws Exception {
+		int itemId = 99999999;
+		when(itemService.getItemDetails(itemId)).thenThrow(new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+
+		mockMvc.perform(
+			get("/api/categories/1/items/" + itemId)
+			).andDo(print())
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").exists());
 	}
 }
 

--- a/backend/src/test/java/kr/codesquad/kiosk/item/service/ItemServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/item/service/ItemServiceTest.java
@@ -1,0 +1,76 @@
+package kr.codesquad.kiosk.item.service;
+
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.fixture.FixtureFactory;
+import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
+import kr.codesquad.kiosk.item.domain.Item;
+import kr.codesquad.kiosk.item.domain.Options;
+import kr.codesquad.kiosk.item.repository.ItemRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ItemServiceTest {
+	@Mock
+	private ItemRepository itemRepository;
+
+	@InjectMocks
+	private ItemService itemService;
+
+	@DisplayName("아이템 아이디로 아이템 상세 항목을 조회할 수 있다.")
+	@Test
+	void givenItemId_whenGetItemDetails_thenReturnsItemDetailsResponse() {
+		// given
+		int itemId = 1;
+		Item item = FixtureFactory.createItem();
+		Map<String, List<Options>> optionsMap = FixtureFactory.createOptionsMap();
+		Map<String, List<String>> options = FixtureFactory.createOptions();
+
+		given(itemRepository.findById(anyInt())).willReturn(Optional.of(item));
+		given(itemRepository.findOptionsByItemId(anyInt())).willReturn(optionsMap);
+
+		// when
+		ItemDetailsResponse itemDetails = itemService.getItemDetails(itemId);
+
+		/// then
+		ItemDetailsResponse response = ItemDetailsResponse.from(item, options);
+
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(itemDetails.id()).isEqualTo(response.id());
+			softAssertions.assertThat(itemDetails.name()).isEqualTo(response.name());
+			softAssertions.assertThat(itemDetails.price()).isEqualTo(response.price());
+			softAssertions.assertThat(itemDetails.options()).isEqualTo(response.options());
+		});
+	}
+
+	@DisplayName("존재하지 않는 아이템 아이디로 아이템 상세 항목을 조회하면 ITEM_NOT_FOUND 에러가 발생한다다.")
+	@Test
+	void givenWrongItemId_whenGetItemDetails_thenThrowsBusinessException() {
+		// given
+		int itemId = 999999;
+		given(itemRepository.findById(anyInt())).willReturn(Optional.empty());
+
+		// when & then
+		assertAll(
+				() -> assertThatThrownBy(() -> itemService.getItemDetails(itemId))
+						.isInstanceOf(BusinessException.class)
+						.extracting("errorCode").isEqualTo(ErrorCode.ITEM_NOT_FOUND),
+				() -> then(itemRepository).should().findById(anyInt()),
+				() -> then(itemRepository).should(times(0)).findOptionsByItemId(anyInt())
+		);
+	}
+}


### PR DESCRIPTION
## What is this PR? 👓
- Story 4번에 해당하는 메뉴 상세 항목을 반환해 주는 API를 추가했습니다.

## Key changes 🔑

### API
-URL `/api/categories/{categoryId}/items/{itemId}`을 호출하여 아래와 같은 결과를 얻을 수 있습니다.
```json
{
    "id": 1,
    "name": "콜드 브루",
    "price": 5000,
    "description": "메뉴에 대한 간단한 소개글",
    "image": "https://i.imgur.com/wCl8osd.png",
    "options": {
        "Temperature": [
            "Ice"
        ],
        "Size": [
            "Large",
            "Medium",
            "Small"
        ]
    }
}
```

### TEST
- Service test 에선 Mock을 사용했습니다. 아이템 아이디로 아이템 상세 항목을 조회할 수 있는지, 존재하지 않는 아이템을 조회할 때 BusinessException 예외가 발생하는지를 테스트 했습니다
- Controlloer test 에는 WebMvcTest와 MockMvc를 사용했습니다. 간단히 정상 응답이 돌아 오는지. JSON 반환값이 반환 되는지를 테스트 했습니다.
    - [*추가*] 존재하지 않는 아이템 아이디를 받았을 때의 테스트 추가하였습니다.

### 기타
- 도메인 객체의 패키지 구조를변경했습니다. 기존엔 모든 도메인 객체를 domain 패키지에 담았습니다. 현재 도메인 별로 패키지를 분리하게 되었습니다.

## To reviewers 👋
- 기존에는 JSON 필드에 인기 메뉴임을 표시하는 `isSignature` 값을 넣어주기로 했습니다. 그러나 현재 주문 수를 집계를 하기 힘든 상황이라 일단 `isSignature` 필드는 제외하고 기능을 구현했습니다.
- `isSignature`는 어떻게 할 지, TEST 코드를 더 추가할지 회의 후 merge 하겠습니다.
- [*추가*] URL에서 `/categories/{categoryId}` 가 필요한지도 이야기해야 할 것 같습니다.

This closes #11