### PR TITLE
[BE] 결제 방식 목록을 반환하는 API 추가

### DIFF
--- a/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorCode.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorCode.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ErrorCode {
-	ITEM_NOT_FOUND(404, "해당 아이템을 찾을 수 없습니다.");
+	ITEM_NOT_FOUND(404, "해당 아이템을 찾을 수 없습니다."),
+	PAYMENTS_NOT_FOUND(404, "결제 방식을 찾을 수 없습니다.");
 
 	private final int statusCode;
 	private final String description;

--- a/backend/src/main/java/kr/codesquad/kiosk/payment/controller/PaymentController.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/payment/controller/PaymentController.java
@@ -1,0 +1,25 @@
+package kr.codesquad.kiosk.payment.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.codesquad.kiosk.payment.controller.response.PaymentResponse;
+import kr.codesquad.kiosk.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class PaymentController {
+
+	private final PaymentService paymentService;
+
+	@GetMapping("/api/payments")
+	public ResponseEntity<List<PaymentResponse>> getPayments() {
+		return ResponseEntity.ok()
+			.body(paymentService.getPayments());
+	}
+
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/payment/controller/PaymentController.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/payment/controller/PaymentController.java
@@ -1,12 +1,10 @@
 package kr.codesquad.kiosk.payment.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import kr.codesquad.kiosk.payment.controller.response.PaymentResponse;
+import kr.codesquad.kiosk.payment.controller.response.PaymentsResponse;
 import kr.codesquad.kiosk.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 
@@ -17,9 +15,9 @@ public class PaymentController {
 	private final PaymentService paymentService;
 
 	@GetMapping("/api/payments")
-	public ResponseEntity<List<PaymentResponse>> getPayments() {
+	public ResponseEntity<PaymentsResponse> getPayments() {
 		return ResponseEntity.ok()
-			.body(paymentService.getPayments());
+			.body(new PaymentsResponse(paymentService.getPayments()));
 	}
 
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/payment/controller/PaymentController.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/payment/controller/PaymentController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class PaymentController {
-
 	private final PaymentService paymentService;
 
 	@GetMapping("/api/payments")
@@ -19,5 +18,4 @@ public class PaymentController {
 		return ResponseEntity.ok()
 			.body(new PaymentsResponse(paymentService.getPayments()));
 	}
-
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/payment/controller/response/PaymentResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/payment/controller/response/PaymentResponse.java
@@ -1,0 +1,18 @@
+package kr.codesquad.kiosk.payment.controller.response;
+
+import kr.codesquad.kiosk.payment.domain.Payment;
+
+public record PaymentResponse(
+	Integer id,
+	String name,
+	String image
+) {
+	public static PaymentResponse from(Payment payment) {
+		return
+			new PaymentResponse(
+				payment.getId(),
+				payment.getName(),
+				payment.getImage()
+			);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/payment/controller/response/PaymentsResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/payment/controller/response/PaymentsResponse.java
@@ -1,0 +1,7 @@
+package kr.codesquad.kiosk.payment.controller.response;
+
+import java.util.List;
+
+public record PaymentsResponse (
+	List<PaymentResponse> payments
+) {}

--- a/backend/src/main/java/kr/codesquad/kiosk/payment/domain/Payment.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/payment/domain/Payment.java
@@ -1,8 +1,10 @@
 package kr.codesquad.kiosk.payment.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class Payment {
 	private int id;
 	private String name;

--- a/backend/src/main/java/kr/codesquad/kiosk/payment/repository/PaymentRepository.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/payment/repository/PaymentRepository.java
@@ -1,0 +1,37 @@
+package kr.codesquad.kiosk.payment.repository;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import kr.codesquad.kiosk.payment.domain.Payment;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class PaymentRepository {
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+
+	private final RowMapper<Payment> paymentRowMapper = (rs, rowNum) -> new Payment(
+		rs.getInt("id"),
+		rs.getString("name"),
+		rs.getString("image")
+	);
+
+	public List<Payment> findAll() {
+		try {
+			String sql = "SELECT id, name, image FROM payment";
+			return Collections.unmodifiableList(
+				jdbcTemplate.query(
+					sql,
+					paymentRowMapper)
+			);
+		} catch (EmptyResultDataAccessException e) {
+			return List.of();
+		}
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/payment/service/PaymentService.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/payment/service/PaymentService.java
@@ -1,0 +1,32 @@
+package kr.codesquad.kiosk.payment.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.payment.controller.response.PaymentResponse;
+import kr.codesquad.kiosk.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class PaymentService {
+	private final PaymentRepository paymentRepository;
+
+	@Transactional(readOnly = true)
+	public List<PaymentResponse> getPayments() {
+		List<PaymentResponse> payments = paymentRepository.findAll()
+			.stream()
+			.map(PaymentResponse::from)
+			.toList();
+
+		if(payments.isEmpty()) {
+			throw new BusinessException(ErrorCode.PAYMENTS_NOT_FOUND);
+		}
+
+		return payments;
+	}
+}

--- a/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
@@ -3,6 +3,8 @@ package kr.codesquad.kiosk.fixture;
 import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
 import kr.codesquad.kiosk.item.domain.Item;
 import kr.codesquad.kiosk.item.domain.Options;
+import kr.codesquad.kiosk.payment.controller.response.PaymentResponse;
+import kr.codesquad.kiosk.payment.domain.Payment;
 
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +30,23 @@ public class FixtureFactory {
 
 	public static Map<String, List<Options>> createOptionsMap() {
 		return Map.of("Size", List.of(new Options(1, "Small"), new Options(2, "Medium"), new Options(3, "Large")),
-				"Temperature", List.of(new Options(4, "Ice")));
+			"Temperature", List.of(new Options(4, "Ice")));
+	}
+
+	public static List<PaymentResponse> createPaymentResponses() {
+		return createPayments().stream()
+			.map(PaymentResponse::from)
+			.toList();
+	}
+
+	public static List<Payment> createPayments() {
+		return List.of(
+			new Payment(1, "카드 결제", "url"),
+			new Payment(3, "현금 결제", "url")
+		);
+	}
+
+	public static List<Payment> createEmptyPayments() {
+		return List.of();
 	}
 }

--- a/backend/src/test/java/kr/codesquad/kiosk/payment/controller/PaymentControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/payment/controller/PaymentControllerTest.java
@@ -1,0 +1,60 @@
+package kr.codesquad.kiosk.payment.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.fixture.FixtureFactory;
+import kr.codesquad.kiosk.payment.controller.response.PaymentResponse;
+import kr.codesquad.kiosk.payment.service.PaymentService;
+
+@WebMvcTest(controllers = PaymentController.class)
+class PaymentControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	PaymentService paymentService;
+
+	@DisplayName("결제 방식 목록을 조회할 수 있다.")
+	@Test
+	void whenGetPayments_then200OK() throws Exception {
+		List<PaymentResponse> payments = FixtureFactory.createPaymentResponses();
+		when(paymentService.getPayments()).thenReturn(payments);
+
+		mockMvc.perform(
+				get("/api/payments")
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].id").exists())
+			.andExpect(jsonPath("$[0].name").exists())
+			.andExpect(jsonPath("$[0].image").exists());
+	}
+
+	@DisplayName("결제 방식 목록이 없으면 404 Not Found를 반환한다.")
+	@Test
+	void givenNoPayments_whenGetItemDetails_thenResponse404NotFound() throws Exception {
+		when(paymentService.getPayments()).thenThrow(new BusinessException(ErrorCode.PAYMENTS_NOT_FOUND));
+
+		mockMvc.perform(
+				get("/api/payments")
+			)
+			.andDo(print())
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value(ErrorCode.PAYMENTS_NOT_FOUND.getDescription()));
+	}
+}

--- a/backend/src/test/java/kr/codesquad/kiosk/payment/controller/PaymentControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/payment/controller/PaymentControllerTest.java
@@ -40,9 +40,7 @@ class PaymentControllerTest {
 			)
 			.andDo(print())
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$[0].id").exists())
-			.andExpect(jsonPath("$[0].name").exists())
-			.andExpect(jsonPath("$[0].image").exists());
+			.andExpect(jsonPath("$.payments").exists());
 	}
 
 	@DisplayName("결제 방식 목록이 없으면 404 Not Found를 반환한다.")

--- a/backend/src/test/java/kr/codesquad/kiosk/payment/service/PaymentServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/payment/service/PaymentServiceTest.java
@@ -1,0 +1,68 @@
+package kr.codesquad.kiosk.payment.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.fixture.FixtureFactory;
+import kr.codesquad.kiosk.payment.controller.response.PaymentResponse;
+import kr.codesquad.kiosk.payment.domain.Payment;
+import kr.codesquad.kiosk.payment.repository.PaymentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+	@Mock
+	private PaymentRepository paymentRepository;
+
+	@InjectMocks
+	private PaymentService paymentService;
+
+	@DisplayName("결제 방식 목록을 조회할 수 있다.")
+	@Test
+	void whenGetPayments_thenReturnPayments() {
+		// given
+		List<Payment> payments = FixtureFactory.createPayments();
+		given(paymentRepository.findAll()).willReturn(payments);
+
+		// when
+		List<PaymentResponse> responsesActual = paymentService.getPayments();
+
+		// then
+		List<PaymentResponse> responsesExpected = FixtureFactory.createPaymentResponses();
+
+		SoftAssertions.assertSoftly(softAssertions -> {
+			for (int i = 0; i < responsesActual.size(); i++) {
+				softAssertions.assertThat(responsesActual.get(i).id()).isEqualTo(responsesExpected.get(i).id());
+				softAssertions.assertThat(responsesActual.get(i).name()).isEqualTo(responsesExpected.get(i).name());
+				softAssertions.assertThat(responsesActual.get(i).image()).isEqualTo(responsesExpected.get(i).image());
+			}
+		});
+	}
+
+	@DisplayName("결제 방식 목록을 조회했을 때 목록이 없으면 PAYMENTS_NOT_FOUND 에러가 발생한다.")
+	@Test
+	void whenGetPayments_thenThrowsBusinessException() {
+		// given
+		given(paymentRepository.findAll()).willReturn(FixtureFactory.createEmptyPayments());
+
+		// when & then
+		assertAll(
+			() -> assertThatThrownBy(() -> paymentService.getPayments())
+				.isInstanceOf(BusinessException.class)
+				.extracting("errorCode").isEqualTo(ErrorCode.PAYMENTS_NOT_FOUND),
+			() -> then(paymentRepository).should(times(1)).findAll()
+		);
+	}
+}


### PR DESCRIPTION
## What is this PR? 👓
- Story 8번에 해당하는 결제 방식 목록을 반환하는 API를 추가했습니다.

## Key changes 🔑

### API
- URI : `GET : /api/payments` 를 호출하여 아래와 같은 결과를 얻을 수 있습니다.
```json
{
	"payments":[
		{
			"id": 1,
			"name": "카드 결제",
			"image": "url"
		},
		{
			"id": 2,
			"name": "현금 결제",
			"image": "url"
		}
	]
}
```

### TEST
- Controller와 Service 레이어 테스트 코드 작성했습니다.

## To reviewers 👋
- [해결] Controller에서 return 반환 값을 `List<PaymentResponse>`로 반환하니 JSON 배열에 payments 이름이 생략되어 반환 되는 문제가 있었습니다. payments 이름을 붙이기 위해 `List<PaymentResponse>`를 담고 있는 `PaymentsResponse`를 반환하도록 했습니다.  `PaymentResponse`와 `PaymentsResponse`이름이 비슷해서 고민입니다.
    - [취소] ~~`PaymentResponse`를 제거하고 바로 `PaymentsResponse`를 사용하도록 변경하여 해결했습니다.~~
    -  Domain이 View단으로 넘어가지 않게 다시 rollback 했습니다.
- 결제 목록의 내용은 어플리케이션 단에서 변경될 일 없어야 될 것 같아서 `Collections.unmodifiableList`, `List.of()`로 불변 Collection으로 반환하도록 했습니다.

This closes #20