### PR TITLE
[BE] 결제 완료 시 영수증 정보 반환 API 설계

### DIFF
--- a/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorCode.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorCode.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ErrorCode {
+	ORDER_NOT_FOUND(404, "해당 주문을 찾을 수 없습니다."),
 	ITEM_NOT_FOUND(404, "해당 아이템을 찾을 수 없습니다."),
 	PAYMENTS_NOT_FOUND(404, "결제 방식을 찾을 수 없습니다.");
 

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/controller/OrderController.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/controller/OrderController.java
@@ -1,0 +1,21 @@
+package kr.codesquad.kiosk.orders.controller;
+
+import kr.codesquad.kiosk.orders.controller.dto.response.OrderReceiptResponse;
+import kr.codesquad.kiosk.orders.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class OrderController {
+	private final OrderService orderService;
+
+	@GetMapping("/api/orders/{orderId}")
+	public ResponseEntity<OrderReceiptResponse> getReceipt(@PathVariable Integer orderId) {
+		return ResponseEntity.ok()
+				.body(orderService.getReceipt(orderId));
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/OrderItemResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/OrderItemResponse.java
@@ -1,0 +1,7 @@
+package kr.codesquad.kiosk.orders.controller.dto;
+
+public record OrderItemResponse(
+		String name,
+		Integer quantity
+) {
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/OrdersResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/OrdersResponse.java
@@ -1,0 +1,9 @@
+package kr.codesquad.kiosk.orders.controller.dto;
+
+public record OrdersResponse(
+		String payments,
+		Integer amount,
+		Integer total,
+		Integer change
+) {
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/response/OrderReceiptResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/response/OrderReceiptResponse.java
@@ -1,0 +1,24 @@
+package kr.codesquad.kiosk.orders.controller.dto.response;
+
+import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
+import kr.codesquad.kiosk.orders.controller.dto.OrdersResponse;
+
+import java.util.List;
+
+public record OrderReceiptResponse(
+		List<OrderItemResponse> items,
+		String payments,
+		Integer amount,
+		Integer total,
+		Integer change
+) {
+	public static OrderReceiptResponse from(List<OrderItemResponse> items, OrdersResponse ordersResponse) {
+		return new OrderReceiptResponse(
+				items,
+				ordersResponse.payments(),
+				ordersResponse.amount(),
+				ordersResponse.total(),
+				ordersResponse.change()
+		);
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/repository/OrderRepository.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/repository/OrderRepository.java
@@ -1,0 +1,52 @@
+package kr.codesquad.kiosk.orders.repository;
+
+import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
+import kr.codesquad.kiosk.orders.controller.dto.OrdersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class OrderRepository {
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+
+	public Optional<OrdersResponse> findOrdersResponseByOrderId(Integer orderId) {
+		try {
+			return Optional.ofNullable(
+					jdbcTemplate.queryForObject("SELECT p.name, o.amount, o.total, o.remain " +
+									"FROM orders o " +
+									"JOIN payment p ON o.payment_id = p.id " +
+									"WHERE o.id = :orderId",
+							Map.of("orderId", orderId),
+							(rs, rowNum) -> new OrdersResponse(
+									rs.getString("name"),
+									rs.getInt("amount"),
+									rs.getInt("total"),
+									rs.getInt("remain")
+							)
+					)
+			);
+		} catch (EmptyResultDataAccessException ex) {
+			return Optional.empty();
+		}
+	}
+
+	public List<OrderItemResponse> findOrderItemResponsesByOrderId(Integer orderId) {
+		return jdbcTemplate.query("SELECT i.name, oi.item_quantity " +
+						"FROM orders o " +
+						"JOIN order_item oi ON o.id = oi.orders_id " +
+						"JOIN item i ON oi.item_id = i.id " +
+						"WHERE o.id = :orderId",
+				Map.of("orderId", orderId),
+				(rs, rowNum) -> new OrderItemResponse(
+						rs.getString("name"),
+						rs.getInt("item_quantity")
+				));
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/service/OrderService.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/service/OrderService.java
@@ -1,0 +1,28 @@
+package kr.codesquad.kiosk.orders.service;
+
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
+import kr.codesquad.kiosk.orders.controller.dto.OrdersResponse;
+import kr.codesquad.kiosk.orders.controller.dto.response.OrderReceiptResponse;
+import kr.codesquad.kiosk.orders.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class OrderService {
+	private final OrderRepository orderRepository;
+
+	@Transactional(readOnly = true)
+	public OrderReceiptResponse getReceipt(Integer orderId) {
+		OrdersResponse ordersResponse = orderRepository.findOrdersResponseByOrderId(orderId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+		List<OrderItemResponse> itemResponses = orderRepository.findOrderItemResponsesByOrderId(orderId);
+
+		return OrderReceiptResponse.from(itemResponses, ordersResponse);
+	}
+}

--- a/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
@@ -3,6 +3,8 @@ package kr.codesquad.kiosk.fixture;
 import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
 import kr.codesquad.kiosk.item.domain.Item;
 import kr.codesquad.kiosk.item.domain.Options;
+import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
+import kr.codesquad.kiosk.orders.controller.dto.OrdersResponse;
 import kr.codesquad.kiosk.payment.controller.response.PaymentResponse;
 import kr.codesquad.kiosk.payment.domain.Payment;
 
@@ -30,23 +32,31 @@ public class FixtureFactory {
 
 	public static Map<String, List<Options>> createOptionsMap() {
 		return Map.of("Size", List.of(new Options(1, "Small"), new Options(2, "Medium"), new Options(3, "Large")),
-			"Temperature", List.of(new Options(4, "Ice")));
+				"Temperature", List.of(new Options(4, "Ice")));
 	}
 
 	public static List<PaymentResponse> createPaymentResponses() {
 		return createPayments().stream()
-			.map(PaymentResponse::from)
-			.toList();
+				.map(PaymentResponse::from)
+				.toList();
 	}
 
 	public static List<Payment> createPayments() {
 		return List.of(
-			new Payment(1, "카드 결제", "url"),
-			new Payment(3, "현금 결제", "url")
+				new Payment(1, "카드 결제", "url"),
+				new Payment(3, "현금 결제", "url")
 		);
 	}
 
 	public static List<Payment> createEmptyPayments() {
 		return List.of();
+	}
+
+	public static OrdersResponse createOrdersResponse() {
+		return new OrdersResponse("card", 10000, 10000, 0);
+	}
+
+	public static OrderItemResponse createOrderItemResponse() {
+		return new OrderItemResponse("콜드브루", 2);
 	}
 }

--- a/backend/src/test/java/kr/codesquad/kiosk/orders/controller/OrderControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/orders/controller/OrderControllerTest.java
@@ -1,0 +1,66 @@
+package kr.codesquad.kiosk.orders.controller;
+
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.fixture.FixtureFactory;
+import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
+import kr.codesquad.kiosk.orders.controller.dto.OrdersResponse;
+import kr.codesquad.kiosk.orders.controller.dto.response.OrderReceiptResponse;
+import kr.codesquad.kiosk.orders.service.OrderService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = OrderController.class)
+class OrderControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private OrderService orderService;
+
+
+	@DisplayName("올바른 주문 번호가 url parameter로 주어지면 영수증 정보를 조회할 수 있다.")
+	@Test
+	void whenGetReceipt_thenResponse200OK() throws Exception {
+		// given
+		OrderItemResponse orderItemResponse = FixtureFactory.createOrderItemResponse();
+		OrdersResponse ordersResponse = FixtureFactory.createOrdersResponse();
+		given(orderService.getReceipt(anyInt()))
+				.willReturn(OrderReceiptResponse.from(List.of(orderItemResponse), ordersResponse));
+
+		// when & then
+		mockMvc.perform(get("/api/orders/1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.items").exists())
+				.andExpect(jsonPath("$.payments").exists())
+				.andExpect(jsonPath("$.amount").exists())
+				.andExpect(jsonPath("$.total").exists())
+				.andExpect(jsonPath("$.change").exists())
+				.andDo(print());
+	}
+
+	@DisplayName("영수증 정보를 조회할 때 잘못된 주문번호가 주어지면 404 NOT FOUND를 응답한다.")
+	@Test
+	void givenWrongOrderId_whenGetReceipt_thenResponse404NotFound() throws Exception {
+		// given
+		given(orderService.getReceipt(anyInt())).willThrow(new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+		// when & then
+		mockMvc.perform(get("/api/orders/1"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("해당 주문을 찾을 수 없습니다."));
+	}
+}

--- a/backend/src/test/java/kr/codesquad/kiosk/orders/service/OrderServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/orders/service/OrderServiceTest.java
@@ -1,0 +1,75 @@
+package kr.codesquad.kiosk.orders.service;
+
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.fixture.FixtureFactory;
+import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
+import kr.codesquad.kiosk.orders.controller.dto.response.OrderReceiptResponse;
+import kr.codesquad.kiosk.orders.repository.OrderRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+	@Mock
+	private OrderRepository orderRepository;
+
+	@InjectMocks
+	private OrderService orderService;
+
+	@DisplayName("영수증 정보를 얻을 때 주문번호가 주어지면 영수증 정보를 얻는데 성공한다.")
+	@Test
+	void givenOrderId_whenGetReceipt_thenReturnsOrderReceipt() {
+		// given
+		int orderId = 1;
+
+		given(orderRepository.findOrdersResponseByOrderId(orderId))
+				.willReturn(Optional.of(FixtureFactory.createOrdersResponse()));
+		given(orderRepository.findOrderItemResponsesByOrderId(orderId))
+				.willReturn(List.of(FixtureFactory.createOrderItemResponse()));
+
+		// when
+		OrderReceiptResponse receipt = orderService.getReceipt(orderId);
+
+		// then
+		SoftAssertions.assertSoftly(softAssertions -> {
+			softAssertions.assertThat(receipt.items()).isEqualTo(List.of(new OrderItemResponse("콜드브루", 2)));
+			softAssertions.assertThat(receipt.payments()).isEqualTo("card");
+			softAssertions.assertThat(receipt.amount()).isEqualTo(10000);
+			softAssertions.assertThat(receipt.total()).isEqualTo(10000);
+			softAssertions.assertThat(receipt.change()).isEqualTo(0);
+		});
+	}
+
+	@DisplayName("영수증 정보를 얻을 때 잘못된 주문번호가 주어지면 예외를 던진다.")
+	@Test
+	void givenWrongOrderId_whenGetReceipt_thenThrowsException() {
+		// given
+		given(orderRepository.findOrdersResponseByOrderId(anyInt())).willReturn(Optional.empty());
+
+		// when & then
+		assertAll(
+				() -> assertThatThrownBy(() -> orderService.getReceipt(9876))
+						.isInstanceOf(BusinessException.class)
+						.extracting("errorCode")
+						.isEqualTo(ErrorCode.ORDER_NOT_FOUND),
+				() -> then(orderRepository).should(times(1)).findOrdersResponseByOrderId(anyInt()),
+				() -> then(orderRepository).should(times(0)).findOrderItemResponsesByOrderId(anyInt())
+		);
+	}
+}


### PR DESCRIPTION
## What is this PR? 👓
- 결제 완료 시 영수증 정보를 반환하는 API 설계에 대한 PR 입니다.
- API 는 아래와 같습니다.
```json
{
	"items": [
		{
			"name": "",
			"quantity": ""
		},
	],
	"payments": "",
	"amount": "",
	"total": "",
	"change": ""
}
```

## Key changes 🔑
- 영수증 정보를 반환하는 API 를 설계했습니다.
- 이에 대한 테스트코드를 작성했습니다.

## To reviewers 👋
- 노션에 적혀있는 것은 `영수증 노출 페이지로 이동`인데 이게 의미하는게 `Location` 헤더에 redirect url을 주고 응답을 3XX대로 주는 건지가 확실하지 않습니다.
  - 따라서 주문에 대한 영수증 정보만 반환하도록 API를 설계했습니다.

This closes #32 