### PR TITLE
[BE] 사용자가 네비게이션 바를 선택하면 해당 메뉴들을 반환하는 API 설계

### DIFF
--- a/backend/src/main/java/kr/codesquad/kiosk/category/controller/CategoryController.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/controller/CategoryController.java
@@ -1,15 +1,14 @@
 package kr.codesquad.kiosk.category.controller;
 
-import java.util.List;
-
+import kr.codesquad.kiosk.category.controller.dto.response.CategoryResponse;
+import kr.codesquad.kiosk.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import kr.codesquad.kiosk.category.dto.response.CategoryResponse;
-import kr.codesquad.kiosk.category.service.CategoryService;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController

--- a/backend/src/main/java/kr/codesquad/kiosk/category/controller/CategoryController.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/controller/CategoryController.java
@@ -1,10 +1,12 @@
 package kr.codesquad.kiosk.category.controller;
 
+import kr.codesquad.kiosk.category.controller.dto.response.CategoryItemsResponse;
 import kr.codesquad.kiosk.category.controller.dto.response.CategoryResponse;
 import kr.codesquad.kiosk.category.service.CategoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +21,10 @@ public class CategoryController {
 	@GetMapping
 	public ResponseEntity<List<CategoryResponse>> showCategories() {
 		return ResponseEntity.ok().body(categoryService.getAllCategories());
+	}
+
+	@GetMapping("/{categoryId}")
+	public ResponseEntity<CategoryItemsResponse> getCategoryItems(@PathVariable Integer categoryId) {
+		return ResponseEntity.ok().body(categoryService.getCategoryItems(categoryId));
 	}
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/category/controller/dto/ItemResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/controller/dto/ItemResponse.java
@@ -1,0 +1,24 @@
+package kr.codesquad.kiosk.category.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public final class ItemResponse {
+	private final Integer id;
+	private final String name;
+	private final Integer price;
+	private Boolean isSignature;
+	private final String image;
+
+	public ItemResponse(Integer id, String name, Integer price, String image) {
+		this.id = id;
+		this.name = name;
+		this.price = price;
+		this.image = image;
+		isSignature = Boolean.FALSE;
+	}
+
+	public void pickSignature() {
+		isSignature = Boolean.TRUE;
+	}
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/category/controller/dto/response/CategoryItemsResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/controller/dto/response/CategoryItemsResponse.java
@@ -1,0 +1,10 @@
+package kr.codesquad.kiosk.category.controller.dto.response;
+
+import kr.codesquad.kiosk.category.controller.dto.ItemResponse;
+
+import java.util.List;
+
+public record CategoryItemsResponse(
+		List<ItemResponse> items
+) {
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/category/controller/dto/response/CategoryItemsResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/controller/dto/response/CategoryItemsResponse.java
@@ -5,6 +5,7 @@ import kr.codesquad.kiosk.category.controller.dto.ItemResponse;
 import java.util.List;
 
 public record CategoryItemsResponse(
+		Integer id,
 		List<ItemResponse> items
 ) {
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/category/controller/dto/response/CategoryResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/controller/dto/response/CategoryResponse.java
@@ -1,13 +1,13 @@
-package kr.codesquad.kiosk.category.dto.response;
+package kr.codesquad.kiosk.category.controller.dto.response;
 
 public record CategoryResponse(
-	Integer id,
-	String name
+		Integer id,
+		String name
 ) {
 	public static CategoryResponse from(int id, String name) {
 		return new CategoryResponse(
-			id,
-			name
+				id,
+				name
 		);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/repository/CategoryRepository.java
@@ -1,22 +1,29 @@
 package kr.codesquad.kiosk.category.repository;
 
-import java.util.Collections;
-import java.util.List;
-
+import kr.codesquad.kiosk.category.controller.dto.ItemResponse;
+import kr.codesquad.kiosk.category.domain.Category;
+import lombok.RequiredArgsConstructor;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import kr.codesquad.kiosk.category.domain.Category;
-import lombok.RequiredArgsConstructor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Repository
 public class CategoryRepository {
 	private final NamedParameterJdbcTemplate jdbcTemplate;
 	private final RowMapper<Category> categoryRowMapper = ((rs, rowNum) -> new Category(rs.getInt("id"),
-		rs.getString("name")));
+			rs.getString("name")));
+	private final RowMapper<ItemResponse> itemResponseRowMapper = ((rs, rowNum) -> new ItemResponse(
+			rs.getInt("id"),
+			rs.getString("name"),
+			rs.getInt("price"),
+			rs.getString("image")
+	));
 
 	public List<Category> findAll() {
 		try {
@@ -24,5 +31,32 @@ public class CategoryRepository {
 		} catch (EmptyResultDataAccessException e) {
 			return List.of();
 		}
+	}
+
+	public List<ItemResponse> findItemsByCategoryId(Integer categoryId) {
+		final String sql = "SELECT i.id, i.name, i.price, i.image, " +
+				"CASE WHEN oi.total_quantity is null THEN 0 ELSE oi.total_quantity END AS total_quantity " +
+				"FROM item as i " +
+				"LEFT JOIN (" +
+				"SELECT item_id, SUM(item_quantity) AS total_quantity " +
+				"FROM order_item " +
+				"JOIN orders ON order_item.orders_id = orders.id " +
+				"WHERE DATE(orders.order_date) = CURDATE()" +
+				"GROUP BY item_id) AS oi ON i.id = oi.item_id " +
+				"JOIN category AS c ON i.category_id = c.id " +
+				"WHERE c.id = :categoryId " +
+				"ORDER BY total_quantity DESC, i.id";
+
+		return jdbcTemplate.query(sql, Map.of("categoryId", categoryId), itemResponseRowMapper);
+	}
+
+	public List<Integer> findTop3ItemsByCategoryId(Integer categoryId) {
+		return jdbcTemplate.query("SELECT i.id, coalesce(SUM(oi.item_quantity), 0) as total_quantity " +
+				"FROM item i " +
+				"LEFT JOIN order_item oi ON i.id = oi.item_id " +
+				"WHERE i.category_id = :categoryId " +
+				"GROUP BY i.id " +
+				"ORDER BY total_quantity DESC, i.id " +
+				"LIMIT 3", Map.of("categoryId", categoryId), (rs, rowNum) -> rs.getInt("id"));
 	}
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/category/service/CategoryService.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/service/CategoryService.java
@@ -1,5 +1,7 @@
 package kr.codesquad.kiosk.category.service;
 
+import kr.codesquad.kiosk.category.controller.dto.ItemResponse;
+import kr.codesquad.kiosk.category.controller.dto.response.CategoryItemsResponse;
 import kr.codesquad.kiosk.category.controller.dto.response.CategoryResponse;
 import kr.codesquad.kiosk.category.repository.CategoryRepository;
 import kr.codesquad.kiosk.exception.BusinessException;
@@ -28,5 +30,21 @@ public class CategoryService {
 		}
 
 		return categories;
+	}
+
+	@Transactional(readOnly = true)
+	public CategoryItemsResponse getCategoryItems(Integer categoryId) {
+		List<ItemResponse> itemResponses = categoryRepository.findItemsByCategoryId(categoryId);
+		if (itemResponses.isEmpty()) {
+			throw new BusinessException(ErrorCode.CATEGORY_NOT_FOUND);
+		}
+
+		List<Integer> top3ItemIds = categoryRepository.findTop3ItemsByCategoryId(categoryId);
+
+		itemResponses.stream()
+				.filter(itemResponse -> top3ItemIds.contains(itemResponse.getId()))
+				.forEach(ItemResponse::pickSignature);
+
+		return new CategoryItemsResponse(itemResponses);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/category/service/CategoryService.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/service/CategoryService.java
@@ -1,16 +1,15 @@
 package kr.codesquad.kiosk.category.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import kr.codesquad.kiosk.category.dto.response.CategoryResponse;
+import kr.codesquad.kiosk.category.controller.dto.response.CategoryResponse;
 import kr.codesquad.kiosk.category.repository.CategoryRepository;
 import kr.codesquad.kiosk.exception.BusinessException;
 import kr.codesquad.kiosk.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -20,9 +19,9 @@ public class CategoryService {
 	@Transactional(readOnly = true)
 	public List<CategoryResponse> getAllCategories() {
 		List<CategoryResponse> categories = categoryRepository.findAll()
-			.stream()
-			.map(category -> CategoryResponse.from(category.getId(), category.getName()))
-			.collect(Collectors.toList());
+				.stream()
+				.map(category -> CategoryResponse.from(category.getId(), category.getName()))
+				.collect(Collectors.toList());
 
 		if (categories.isEmpty()) {
 			throw new BusinessException(ErrorCode.EMPTY_RESULT);

--- a/backend/src/main/java/kr/codesquad/kiosk/category/service/CategoryService.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/category/service/CategoryService.java
@@ -45,6 +45,6 @@ public class CategoryService {
 				.filter(itemResponse -> top3ItemIds.contains(itemResponse.getId()))
 				.forEach(ItemResponse::pickSignature);
 
-		return new CategoryItemsResponse(itemResponses);
+		return new CategoryItemsResponse(categoryId, itemResponses);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorCode.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/exception/ErrorCode.java
@@ -9,7 +9,8 @@ public enum ErrorCode {
 	EMPTY_RESULT(500, "데이터 불러오기를 실패했습니다."),
 	ORDER_NOT_FOUND(404, "해당 주문을 찾을 수 없습니다."),
 	ITEM_NOT_FOUND(404, "해당 아이템을 찾을 수 없습니다."),
-	PAYMENTS_NOT_FOUND(404, "결제 방식을 찾을 수 없습니다.");
+	PAYMENTS_NOT_FOUND(404, "결제 방식을 찾을 수 없습니다."),
+	CATEGORY_NOT_FOUND(404, "해당 카테고리를 찾을 수 없습니다.");
 
 	private final int statusCode;
 	private final String description;

--- a/backend/src/test/java/kr/codesquad/kiosk/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/category/controller/CategoryControllerTest.java
@@ -1,13 +1,10 @@
 package kr.codesquad.kiosk.category.controller;
 
-import static org.hamcrest.Matchers.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.List;
-
+import kr.codesquad.kiosk.category.controller.dto.response.CategoryResponse;
+import kr.codesquad.kiosk.category.service.CategoryService;
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.fixture.FixtureFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,11 +12,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import kr.codesquad.kiosk.category.dto.response.CategoryResponse;
-import kr.codesquad.kiosk.category.service.CategoryService;
-import kr.codesquad.kiosk.exception.BusinessException;
-import kr.codesquad.kiosk.exception.ErrorCode;
-import kr.codesquad.kiosk.fixture.FixtureFactory;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = CategoryController.class)
 class CategoryControllerTest {
@@ -39,12 +39,12 @@ class CategoryControllerTest {
 
 		// when & then
 		mockMvc.perform(
-				get("/api/categories")
-			)
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.length()").value(response.size()))
-			.andExpect(jsonPath("$[*].id").value(hasItems(response.stream().map(CategoryResponse::id).toArray())))
-			.andExpect(jsonPath("$[*].name").value(hasItems(response.stream().map(CategoryResponse::name).toArray())));
+						get("/api/categories")
+				)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.length()").value(response.size()))
+				.andExpect(jsonPath("$[*].id").value(hasItems(response.stream().map(CategoryResponse::id).toArray())))
+				.andExpect(jsonPath("$[*].name").value(hasItems(response.stream().map(CategoryResponse::name).toArray())));
 	}
 
 	@DisplayName("카테고리 항목을 불러오지 못하면 500 Connection Error를 반환한다.")
@@ -55,10 +55,10 @@ class CategoryControllerTest {
 
 		// when & then
 		mockMvc.perform(
-				get("/api/categories")
-			)
-			.andDo(print())
-			.andExpect(status().isInternalServerError())
-			.andExpect(jsonPath("$.message").value(ErrorCode.EMPTY_RESULT.getDescription()));
+						get("/api/categories")
+				)
+				.andDo(print())
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.message").value(ErrorCode.EMPTY_RESULT.getDescription()));
 	}
 }

--- a/backend/src/test/java/kr/codesquad/kiosk/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/category/controller/CategoryControllerTest.java
@@ -77,6 +77,7 @@ class CategoryControllerTest {
 						get("/api/categories/1")
 				)
 				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value(1))
 				.andExpect(jsonPath("$.items").exists())
 				.andExpect(jsonPath("$['items'][*]['id']").exists())
 				.andExpect(jsonPath("$['items'][*]['name']").exists())

--- a/backend/src/test/java/kr/codesquad/kiosk/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/category/service/CategoryServiceTest.java
@@ -1,12 +1,11 @@
 package kr.codesquad.kiosk.category.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
+import kr.codesquad.kiosk.category.controller.dto.response.CategoryResponse;
+import kr.codesquad.kiosk.category.domain.Category;
+import kr.codesquad.kiosk.category.repository.CategoryRepository;
+import kr.codesquad.kiosk.exception.BusinessException;
+import kr.codesquad.kiosk.exception.ErrorCode;
+import kr.codesquad.kiosk.fixture.FixtureFactory;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,12 +14,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import kr.codesquad.kiosk.category.domain.Category;
-import kr.codesquad.kiosk.category.dto.response.CategoryResponse;
-import kr.codesquad.kiosk.category.repository.CategoryRepository;
-import kr.codesquad.kiosk.exception.BusinessException;
-import kr.codesquad.kiosk.exception.ErrorCode;
-import kr.codesquad.kiosk.fixture.FixtureFactory;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CategoryServiceTest {
@@ -44,15 +43,15 @@ class CategoryServiceTest {
 		// then
 		SoftAssertions softAssertions = new SoftAssertions();
 		softAssertions.assertThat(actualResponse)
-			.isNotNull()
-			.hasSize(categories.size());
+				.isNotNull()
+				.hasSize(categories.size());
 
 		List<CategoryResponse> expectedResponse = categories.stream()
-			.map(category -> CategoryResponse.from(category.getId(), category.getName()))
-			.collect(Collectors.toList());
+				.map(category -> CategoryResponse.from(category.getId(), category.getName()))
+				.collect(Collectors.toList());
 
 		softAssertions.assertThat(actualResponse)
-			.containsExactlyElementsOf(expectedResponse);
+				.containsExactlyElementsOf(expectedResponse);
 
 		softAssertions.assertAll();
 	}
@@ -65,9 +64,9 @@ class CategoryServiceTest {
 
 		// when & then
 		assertAll(
-			() -> assertThatThrownBy(() -> categoryService.getAllCategories()).isInstanceOf(BusinessException.class)
-				.extracting("errorCode")
-				.isEqualTo(ErrorCode.EMPTY_RESULT),
-			() -> then(categoryRepository).should(times(1)).findAll());
+				() -> assertThatThrownBy(() -> categoryService.getAllCategories()).isInstanceOf(BusinessException.class)
+						.extracting("errorCode")
+						.isEqualTo(ErrorCode.EMPTY_RESULT),
+				() -> then(categoryRepository).should(times(1)).findAll());
 	}
 }

--- a/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
@@ -110,6 +110,6 @@ public class FixtureFactory {
 	}
 
 	public static CategoryItemsResponse createCategoryItemsResponse() {
-		return new CategoryItemsResponse(createItemResponses());
+		return new CategoryItemsResponse(1, createItemResponses());
 	}
 }

--- a/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
@@ -1,5 +1,7 @@
 package kr.codesquad.kiosk.fixture;
 
+import kr.codesquad.kiosk.category.controller.dto.ItemResponse;
+import kr.codesquad.kiosk.category.controller.dto.response.CategoryItemsResponse;
 import kr.codesquad.kiosk.category.controller.dto.response.CategoryResponse;
 import kr.codesquad.kiosk.category.domain.Category;
 import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
@@ -97,5 +99,17 @@ public class FixtureFactory {
 
 	public static OrderItemResponse createOrderItemResponse() {
 		return new OrderItemResponse("콜드브루", 2, 10000);
+	}
+
+	public static List<ItemResponse> createItemResponses() {
+		return List.of(
+				new ItemResponse(1, "콜드 브루", 5000, "url"),
+				new ItemResponse(2, "돌체 콜드 브루", 5500, "url"),
+				new ItemResponse(3, "아메리카노", 4500, "url")
+		);
+	}
+
+	public static CategoryItemsResponse createCategoryItemsResponse() {
+		return new CategoryItemsResponse(createItemResponses());
 	}
 }

--- a/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
@@ -1,7 +1,7 @@
 package kr.codesquad.kiosk.fixture;
 
+import kr.codesquad.kiosk.category.controller.dto.response.CategoryResponse;
 import kr.codesquad.kiosk.category.domain.Category;
-import kr.codesquad.kiosk.category.dto.response.CategoryResponse;
 import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
 import kr.codesquad.kiosk.item.controller.dto.response.OptionsResponse;
 import kr.codesquad.kiosk.item.domain.Item;
@@ -58,11 +58,11 @@ public class FixtureFactory {
 		Map<String, List<OptionsResponse>> map = new HashMap<>();
 
 		map.put("Size",
-			List.of(
-				new OptionsResponse(1, "Small"),
-				new OptionsResponse(2, "Medium"),
-				new OptionsResponse(3, "Large")
-			)
+				List.of(
+						new OptionsResponse(1, "Small"),
+						new OptionsResponse(2, "Medium"),
+						new OptionsResponse(3, "Large")
+				)
 		);
 		map.put("Temperature", List.of(new OptionsResponse(5, "Ice")));
 
@@ -71,7 +71,7 @@ public class FixtureFactory {
 
 	public static Map<String, List<Options>> createOptionsMap() {
 		return Map.of("Size", List.of(new Options(1, "Small"), new Options(2, "Medium"), new Options(3, "Large")),
-			"Temperature", List.of(new Options(5, "Ice")));
+				"Temperature", List.of(new Options(5, "Ice")));
 	}
 
 	public static List<PaymentResponse> createPaymentResponses() {


### PR DESCRIPTION
## What is this PR? 👓
- 사용자가 네비게이션 바를 선택하면 해당 메뉴들을 반환하는 API에 대한 PR 입니다.
- API 는 아래와 같습니다.
```json
{
	"items": [
		{
			"id": "",
			"name": "",
			"price": "",
			"isSignature": "",
			"image": "{url}"
		}
	]
}
```

## Key changes 🔑
- 사용자가 네비게이션 바를 선택하면 해당 메뉴들을 반환하는 API를 설계했습니다.
- URI가 `api/categories/{categoryId}` 과 같이 들어오면 카테고리 아이디에 해당하는 메뉴 목록을 반환합니다.
- 이에 대한 테스트코드도 작성했습니다.

## To reviewers 👋
- 당일 카테고리별 판매량 순으로 정렬이 되는지 확인해주세요.
- `isSignature`필드는 카테고리별 전체 누적 판매량 상위 3개 항목만 `true`인지 확인해주세요.

This closes #56 