### PR TITLE
[BE] 영수증 노출 시 옵션 항목도 함께 출력

### DIFF
--- a/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/OptionDetailsParam.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/OptionDetailsParam.java
@@ -1,0 +1,7 @@
+package kr.codesquad.kiosk.orders.controller.dto;
+
+public record OptionDetailsParam(
+		Integer id,
+		String name
+) {
+}

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/OrderItemResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/OrderItemResponse.java
@@ -1,8 +1,12 @@
 package kr.codesquad.kiosk.orders.controller.dto;
 
+import java.util.List;
+import java.util.Map;
+
 public record OrderItemResponse(
-	String name,
-	Integer quantity,
-	Integer price
+		String name,
+		Integer quantity,
+		Integer price,
+		List<Map<String, OptionDetailsParam>> options
 ) {
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/response/OrderReceiptResponse.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/controller/dto/response/OrderReceiptResponse.java
@@ -1,24 +1,26 @@
 package kr.codesquad.kiosk.orders.controller.dto.response;
 
-import java.util.List;
-
 import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
 import kr.codesquad.kiosk.orders.controller.dto.OrdersResponse;
 
+import java.util.List;
+
 public record OrderReceiptResponse(
-	List<OrderItemResponse> items,
-	String payments,
-	Integer amount,
-	Integer total,
-	Integer remain
+		Integer id,
+		List<OrderItemResponse> items,
+		String payments,
+		Integer amount,
+		Integer total,
+		Integer remain
 ) {
-	public static OrderReceiptResponse from(List<OrderItemResponse> items, OrdersResponse ordersResponse) {
+	public static OrderReceiptResponse from(Integer orderId, List<OrderItemResponse> items, OrdersResponse ordersResponse) {
 		return new OrderReceiptResponse(
-			items,
-			ordersResponse.payments(),
-			ordersResponse.amount(),
-			ordersResponse.total(),
-			ordersResponse.remain()
+				orderId,
+				items,
+				ordersResponse.payments(),
+				ordersResponse.amount(),
+				ordersResponse.total(),
+				ordersResponse.remain()
 		);
 	}
 }

--- a/backend/src/main/java/kr/codesquad/kiosk/orders/service/OrderService.java
+++ b/backend/src/main/java/kr/codesquad/kiosk/orders/service/OrderService.java
@@ -1,11 +1,5 @@
 package kr.codesquad.kiosk.orders.service;
 
-import java.util.List;
-import java.util.Random;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import kr.codesquad.kiosk.exception.BusinessException;
 import kr.codesquad.kiosk.exception.ErrorCode;
 import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
@@ -17,6 +11,11 @@ import kr.codesquad.kiosk.orders.domain.OrderResultType;
 import kr.codesquad.kiosk.orders.repository.OrderRepository;
 import kr.codesquad.kiosk.payment.domain.PaymentType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Random;
 
 @RequiredArgsConstructor
 @Service
@@ -27,10 +26,10 @@ public class OrderService {
 	@Transactional(readOnly = true)
 	public OrderReceiptResponse getReceipt(Integer orderId) {
 		OrdersResponse ordersResponse = orderRepository.findOrdersResponseByOrderId(orderId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+				.orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 		List<OrderItemResponse> itemResponses = orderRepository.findOrderItemResponsesByOrderId(orderId);
 
-		return OrderReceiptResponse.from(itemResponses, ordersResponse);
+		return OrderReceiptResponse.from(orderId, itemResponses, ordersResponse);
 	}
 
 	@Transactional
@@ -41,7 +40,7 @@ public class OrderService {
 
 		if (orderResultType == OrderResultType.SUCCESS) {
 			return new OrdersIdResponse(
-				orderRepository.saveOrder(request.toOrders())
+					orderRepository.saveOrder(request.toOrders())
 			);
 		}
 

--- a/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/fixture/FixtureFactory.java
@@ -1,19 +1,14 @@
 package kr.codesquad.kiosk.fixture;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import kr.codesquad.kiosk.category.controller.dto.ItemResponse;
 import kr.codesquad.kiosk.category.controller.dto.response.CategoryItemsResponse;
 import kr.codesquad.kiosk.category.controller.dto.response.CategoryResponse;
-
 import kr.codesquad.kiosk.category.domain.Category;
 import kr.codesquad.kiosk.item.controller.dto.response.ItemDetailsResponse;
 import kr.codesquad.kiosk.item.controller.dto.response.OptionsResponse;
 import kr.codesquad.kiosk.item.domain.Item;
 import kr.codesquad.kiosk.item.domain.Options;
+import kr.codesquad.kiosk.orders.controller.dto.OptionDetailsParam;
 import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
 import kr.codesquad.kiosk.orders.controller.dto.OrdersResponse;
 import kr.codesquad.kiosk.orders.controller.dto.request.OrderItemRequest;
@@ -22,6 +17,11 @@ import kr.codesquad.kiosk.orders.controller.dto.request.OrdersRequest;
 import kr.codesquad.kiosk.orders.controller.dto.response.OrdersIdResponse;
 import kr.codesquad.kiosk.payment.controller.response.PaymentResponse;
 import kr.codesquad.kiosk.payment.domain.Payment;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class FixtureFactory {
 	public static List<CategoryResponse> createCategoriesResponse() {
@@ -83,14 +83,14 @@ public class FixtureFactory {
 
 	public static List<PaymentResponse> createPaymentResponses() {
 		return createPayments().stream()
-			.map(PaymentResponse::from)
-			.toList();
+				.map(PaymentResponse::from)
+				.toList();
 	}
 
 	public static List<Payment> createPayments() {
 		return List.of(
-			new Payment(1, "카드 결제", "url"),
-			new Payment(3, "현금 결제", "url")
+				new Payment(1, "카드 결제", "url"),
+				new Payment(3, "현금 결제", "url")
 		);
 	}
 
@@ -103,7 +103,9 @@ public class FixtureFactory {
 	}
 
 	public static OrderItemResponse createOrderItemResponse() {
-		return new OrderItemResponse("콜드브루", 2, 10000);
+		return new OrderItemResponse("콜드브루", 2, 10000,
+				List.of(Map.of("Size", new OptionDetailsParam(1, "Large")),
+						Map.of("Temperature", new OptionDetailsParam(3, "Hot"))));
 	}
 
 	public static OrderReceiptRequest createOrderReceiptRequest() {
@@ -116,8 +118,8 @@ public class FixtureFactory {
 
 	public static List<OrderItemRequest> createOrderItemsRequest() {
 		return List.of(
-			new OrderItemRequest(1, 4, List.of(1, 5)),
-			new OrderItemRequest(7, 2, List.of(1, 4))
+				new OrderItemRequest(1, 4, List.of(1, 5)),
+				new OrderItemRequest(7, 2, List.of(1, 4))
 		);
 	}
 

--- a/backend/src/test/java/kr/codesquad/kiosk/orders/controller/OrderControllerTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/orders/controller/OrderControllerTest.java
@@ -39,12 +39,16 @@ class OrderControllerTest {
 		OrderItemResponse orderItemResponse = FixtureFactory.createOrderItemResponse();
 		OrdersResponse ordersResponse = FixtureFactory.createOrdersResponse();
 		given(orderService.getReceipt(anyInt()))
-				.willReturn(OrderReceiptResponse.from(List.of(orderItemResponse), ordersResponse));
+				.willReturn(OrderReceiptResponse.from(1, List.of(orderItemResponse), ordersResponse));
 
 		// when & then
 		mockMvc.perform(get("/api/orders/1"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.items").exists())
+				.andExpect(jsonPath("$['items'][*]['name']").exists())
+				.andExpect(jsonPath("$['items'][*]['quantity']").exists())
+				.andExpect(jsonPath("$['items'][*]['price']").exists())
+				.andExpect(jsonPath("$['items'][*]['options']").exists())
 				.andExpect(jsonPath("$.payments").exists())
 				.andExpect(jsonPath("$.amount").exists())
 				.andExpect(jsonPath("$.total").exists())

--- a/backend/src/test/java/kr/codesquad/kiosk/orders/service/OrderServiceTest.java
+++ b/backend/src/test/java/kr/codesquad/kiosk/orders/service/OrderServiceTest.java
@@ -3,6 +3,7 @@ package kr.codesquad.kiosk.orders.service;
 import kr.codesquad.kiosk.exception.BusinessException;
 import kr.codesquad.kiosk.exception.ErrorCode;
 import kr.codesquad.kiosk.fixture.FixtureFactory;
+import kr.codesquad.kiosk.orders.controller.dto.OptionDetailsParam;
 import kr.codesquad.kiosk.orders.controller.dto.OrderItemResponse;
 import kr.codesquad.kiosk.orders.controller.dto.response.OrderReceiptResponse;
 import kr.codesquad.kiosk.orders.repository.OrderRepository;
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,7 +50,9 @@ class OrderServiceTest {
 
 		// then
 		SoftAssertions.assertSoftly(softAssertions -> {
-			softAssertions.assertThat(receipt.items()).isEqualTo(List.of(new OrderItemResponse("콜드브루", 2, 10000)));
+			softAssertions.assertThat(receipt.items()).isEqualTo(List.of(new OrderItemResponse("콜드브루", 2, 10000,
+					List.of(Map.of("Size", new OptionDetailsParam(1, "Large")),
+							Map.of("Temperature", new OptionDetailsParam(3, "Hot"))))));
 			softAssertions.assertThat(receipt.payments()).isEqualTo("card");
 			softAssertions.assertThat(receipt.amount()).isEqualTo(10000);
 			softAssertions.assertThat(receipt.total()).isEqualTo(10000);


### PR DESCRIPTION
## What is this PR? 👓
영수증 노출 시 옵션 항목도 함께 출력하는 기능을 추가하는 PR입니다.
```json
{
	"items": [
		{
			"name": "",
			"quantity": "",
			"price": ""
			"options": [
				{ 
					"size": {"id" : 1 , "name" : "large"}
				},
				{
					"temperature": {"id" : 1 , "name" : "hot"}
				}
			]		
		},
	],
	"payments": "", 
	"amount": "",
	"total": "",
	"remain": "" 
}
```

## Key changes 🔑
영수증 노출 시 옵션 항목도 함께 출력합니다.

## To reviewers 👋
옵션 항목이 잘 출력되는지 확인해주세요!